### PR TITLE
Fix description formatting error in SKILL.md

### DIFF
--- a/swift-concurrency/SKILL.md
+++ b/swift-concurrency/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: swift-concurrency
-description: Expert guidance on Swift Concurrency best practices, patterns, and implementation. Use when developers mention: (1) Swift Concurrency, async/await, actors, or tasks, (2) "use Swift Concurrency" or "modern concurrency patterns", (3) migrating to Swift 6, (4) data races or thread safety issues, (5) refactoring closures to async/await, (6) @MainActor, Sendable, or actor isolation, (7) concurrent code architecture or performance optimization.
+description: 'Expert guidance on Swift Concurrency best practices, patterns, and implementation. Use when developers mention: (1) Swift Concurrency, async/await, actors, or tasks, (2) "use Swift Concurrency" or "modern concurrency patterns", (3) migrating to Swift 6, (4) data races or thread safety issues, (5) refactoring closures to async/await, (6) @MainActor, Sendable, or actor isolation, (7) concurrent code architecture or performance optimization.'
 ---
 # Swift Concurrency
 


### PR DESCRIPTION
error on opencode after installing this skill. it shows as well on github preview

<img width="1452" height="377" alt="image" src="https://github.com/user-attachments/assets/71b0ae81-a781-496a-8559-eda70830fa1c" />
