### PR TITLE
Add quick-fix mode and escalation guidance

### DIFF
--- a/swift-concurrency/SKILL.md
+++ b/swift-concurrency/SKILL.md
@@ -150,7 +150,8 @@ When a developer needs concurrency guidance, follow this decision tree:
 - "Class property 'current' is unavailable from asynchronous contexts" (Thread APIs)
   - Use `references/threading.md` to avoid thread-centric debugging and rely on isolation + Instruments
 - "Actor-isolated type does not conform to protocol" (protocol conformance errors)
-  - Use isolated conformance: `extension Foo: @MainActor SomeProtocol` or refactor requirements to `nonisolated` where safe
+  - First: determine whether the protocol requirements must execute on the actor (for example, UI work on `@MainActor`) or can safely be `nonisolated`.
+  - Then: follow the Quick Fix Playbook entry for actor-isolated protocol conformance and `references/actors.md` for implementation patterns (isolated conformances, `nonisolated` requirements, and escalation steps).
 - XCTest async errors like "wait(...) is unavailable from asynchronous contexts"
   - Use `references/testing.md` (`await fulfillment(of:)` and Swift Testing patterns)
 - Core Data concurrency warnings/errors


### PR DESCRIPTION
## Summary

This PR folds my personal “swift-concurrency-expert” quick‑fix guidance into the main `swift-concurrency` skill so the agent can resolve simple diagnostics fast, and escalate only when needed.

## What changed

- Added **Quick Fix Mode** entry/exit criteria to explicitly gate when fast, minimal fixes are appropriate.
- Added a **Quick Fix Playbook** that maps common diagnostics to smallest safe fixes with escalation triggers.
- Added a clear **Escalation Path** for harder issues (build‑setting discovery → isolation re‑evaluation → decision tree).
- Added **Quick Fix verification** guidance to keep validation proportional to change size.

## Why this improves the skill

These updates add behavior‑level guidance the agent can act on (not just more prose):

- The agent can confidently do small, safe fixes without defaulting to deep dives.
- Diagnostics are mapped to concrete, low‑risk fixes with clear escalation triggers.
- The agent can scale up when needed while still validating quick fixes.

Net effect: faster resolution for simple issues, fewer over‑engineered responses, and a smoother transition to deeper research when complexity increases.

## Scope

Docs only (`swift-concurrency/SKILL.md`), no API or code changes.

## Testing

Not applicable (documentation change only).