### PR TITLE
 Fix @Observable macro syntax 

### DIFF
--- a/swift-concurrency/references/async-algorithms.md
+++ b/swift-concurrency/references/async-algorithms.md
@@ -94,7 +94,8 @@ Wait for inactivity before emitting. Use for rapid inputs like search fields.
 ```swift
 import AsyncAlgorithms
 
-final class ArticleSearcher: @Observable {
+@Observable
+final class ArticleSearcher {
     @MainActor private(set) var results: [Article] = []
     private var searchQueryContinuation: AsyncStream<String>.Continuation?
 
@@ -208,9 +209,9 @@ Emit values at regular intervals. Use for periodic refresh or countdown timers.
 ```swift
 import AsyncAlgorithms
 
-@MainActor
-final class FeedViewModel: @Observable {
-    @Published private(set) var articles: [Article] = []
+@MainActor @Observable
+final class FeedViewModel {
+    private(set) var articles: [Article] = []
     private var refreshTask: Task<Void, Never>?
 
     func startAutoRefresh() {
@@ -645,7 +646,8 @@ final class ArticleSearcher: ObservableObject {
 ```swift
 import AsyncAlgorithms
 
-final class ArticleSearcher: @Observable {
+@Observable
+final class ArticleSearcher {
     @MainActor private(set) var results: [Article] = []
     private var searchQueryContinuation: AsyncStream<String>.Continuation?
 
@@ -709,7 +711,8 @@ final class ArticleLoader: ObservableObject {
 ```swift
 import AsyncAlgorithms
 
-final class ArticleLoader: @Observable {
+@Observable
+final class ArticleLoader {
     @MainActor private(set) var items: [Item] = []
 
     func loadAllSourcesParallel() async {

--- a/swift-concurrency/references/migration.md
+++ b/swift-concurrency/references/migration.md
@@ -661,7 +661,8 @@ struct SearchView: View {
 ```swift
 import AsyncAlgorithms
 
-final class ArticleSearcher: @Observable {
+@Observable
+final class ArticleSearcher {
     @MainActor private(set) var results: [Article] = []
     private var searchQueryContinuation: AsyncStream<String>.Continuation?
 
@@ -736,7 +737,8 @@ final class NotificationObserver: ObservableObject {
 **After: Standard Library Notifications**
 
 ```swift
-final class NotificationObserver: @Observable {
+@Observable
+final class NotificationObserver {
     @MainActor private(set) var notifications: [AppNotification] = []
 
     func startObserving() {
@@ -792,7 +794,8 @@ final class MultiSourceLoader: ObservableObject {
 ```swift
 import AsyncAlgorithms
 
-final class MultiSourceLoader: @Observable {
+@Observable
+final class MultiSourceLoader {
     @MainActor private(set) var items: [Item] = []
 
     func loadFromAllSources() async {


### PR DESCRIPTION
Fix @Observable macro syntax and remove redundant @Published
- Change incorrect : @Observable inheritance syntax to proper @Observable macro placement
- Remove @published from FeedViewModel not needed with @observable                                    

i used claude skill-creator to maintain the format