### PR TITLE
Fix conflicting manifests error when loading plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "swift-concurrency-agent-skill",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "owner": {
     "name": "Antoine van der Lee",
     "email": "contact@avanderlee.com"
@@ -14,7 +14,7 @@
       "name": "swift-concurrency",
       "description": "Expert guidance on Swift Concurrency best practices, patterns, and implementation. Covers async/await, actors, tasks, Sendable conformance, data race prevention, and Swift 6 migration strategies.",
       "repository": "https://github.com/AvdLee/Swift-Concurrency-Agent-Skill",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "author": {
         "name": "Antoine van der Lee",
         "email": "contact@avanderlee.com"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "swift-concurrency",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Expert guidance on Swift Concurrency best practices, patterns, and implementation. Covers async/await, actors, tasks, Sendable conformance, data race prevention, and Swift 6 migration strategies.",
   "author": {
     "name": "Antoine van der Lee",


### PR DESCRIPTION
## Summary

This PR fixes the "conflicting manifests" error that occurs when adding this skill to a project via marketplace.

### The Problem

When loading the plugin, Claude Code reports an error. Running `claude doctor` shows:

```
 Diagnostics
 └ Currently running: native (2.1.30)
 └ Path: /Users/pasashque/.local/share/claude/versions/2.1.30
 └ Invoked: /Users/pasashque/.local/share/claude/versions/2.1.30
 └ Config install method: native
 └ Search: OK (bundled)

 Updates
 └ Auto-updates: enabled
 └ Auto-update channel: latest
 └ Stable version: 2.1.19
 └ Latest version: 2.1.30

 Version Locks
 └ 2.1.30: PID 88093 (running)

 Plugin Errors
 └ 1 plugin error(s) detected:
   └ swift-concurrency@swift-concurrency-agent-skill: Plugin swift-concurrency has conflicting manifests: both plugin.json and marketplace entry specify components. Set strict:
 true in marketplace entry or remove component specs from one location.
```

This happens because both files declare the `skills` array:
- `plugin.json` line 28: `"skills": ["./swift-concurrency"]`
- `marketplace.json` line 53-55: `"skills": ["./swift-concurrency"]`

### The Fix

Remove the `skills` declaration from `plugin.json`, keeping component specs only in `marketplace.json` where the full plugin configuration is defined.

This follows the error message's suggestion to "remove component specs from one location."

## Steps to Reproduce

1. Add this skill to a project via marketplace
2. Run `claude doctor`
3. Observe the plugin error under "Plugin Errors"

## Test Plan

- [ ] Run `claude doctor` after adding the skill - no plugin errors should appear
- [ ] Verify skill loads correctly via the Skill tool