### PR TITLE
fix: set strict mode to resolve conflicting manifests error

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -53,7 +53,7 @@
       "skills": [
         "./swift-concurrency"
       ],
-      "strict": false
+      "strict": true
     }
   ]
 }


### PR DESCRIPTION
## Summary

This PR fixes the "conflicting manifests" error that occurs when adding this skill to a project via marketplace.

### The Problem

When loading the plugin, Claude Code reports an error. Running `claude doctor` shows:

```
 Diagnostics
 └ Currently running: native (2.1.30)
 └ Path: /Users/pasashque/.local/share/claude/versions/2.1.30
 └ Invoked: /Users/pasashque/.local/share/claude/versions/2.1.30
 └ Config install method: native
 └ Search: OK (bundled)

 Updates
 └ Auto-updates: enabled
 └ Auto-update channel: latest
 └ Stable version: 2.1.19
 └ Latest version: 2.1.30

 Version Locks
 └ 2.1.30: PID 88093 (running)

 Plugin Errors
 └ 1 plugin error(s) detected:
   └ swift-concurrency@swift-concurrency-agent-skill: Plugin swift-concurrency has conflicting manifests: both plugin.json and marketplace entry specify components. Set strict:
 true in marketplace entry or remove component specs from one location.
```

Setting `strict: true` tells Claude Code to use only `marketplace.json` for component specs, resolving the conflict.

## Test plan
- [x] Install plugin via `/plugin install swift-concurrency`
- [x] Run `/doctor` and verify no plugin errors