### PR TITLE
feat: add pi package support

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,16 @@ To automatically provide this Skill to everyone working in a repository, configu
 
 When team members open the project, Claude Code will prompt them to install the Skill.
 
-### Option C: Manual install
+### Option C: Using pi package manager
+
+Install via [pi](https://github.com/mariozechner/pi-mono):
+```bash
+pi install https://github.com/AvdLee/Swift-Concurrency-Agent-Skill
+```
+
+The skill will be available automatically in pi sessions.
+
+### Option D: Manual install
 1) **Clone** this repository.  
 2) **Install or symlink** the `swift-concurrency/` folder following your tool’s official skills installation docs (see links below).  
 3) **Use your AI tool** as usual and ask it to use the “swift-concurrency” skill for Swift Concurrency tasks.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,6 @@
+{
+  "keywords": ["pi-package"],
+  "pi": {
+    "skills": ["./swift-concurrency"]
+  }
+}


### PR DESCRIPTION
## What

Adds [pi](https://github.com/mariozechner/pi-mono) package manager support so the skill can be installed with:

```bash
pi install https://github.com/AvdLee/Swift-Concurrency-Agent-Skill
```

## Changes

- `package.json` — minimal pi package manifest (`keywords: ["pi-package"]`, skill path)
- `README.md` — added pi as **Option C** in the installation section, re-lettered existing options

## Notes

- No changes to the skill content itself
- Tested locally with `pi install`