### PR TITLE
fix: update Claude docs link to correct URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ When team members open the project, Claude Code will prompt them to install the 
 
 Follow your tool’s official documentation, here are a few popular ones:
 - **Codex:** [Where to save skills](https://developers.openai.com/codex/skills/#where-to-save-skills)
-- **Claude:** [Using Skills](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/overview#using-skills)
+- **Claude:** [Using Skills](https://docs.claude.com/en/docs/agents-and-tools/agent-skills/overview)
 - **Cursor:** [Enabling Skills](https://cursor.com/docs/context/skills#enabling-skills)
 
 **How to verify**: 


### PR DESCRIPTION
The Claude documentation link in README.md was pointing to the old `platform.claude.com` domain which no longer works.

Updated to the current URL:
https://docs.claude.com/en/docs/agents-and-tools/agent-skills/overview