### PR TITLE
Add technical corrections: executor vs isolation, forward progress, reentrancy patterns

### DIFF
--- a/swift-concurrency/SKILL.md
+++ b/swift-concurrency/SKILL.md
@@ -31,6 +31,9 @@ Guardrails:
 - If recommending `@preconcurrency`, `@unchecked Sendable`, or `nonisolated(unsafe)`, require a documented safety invariant and a follow-up removal plan.
 - Optimize for the smallest safe change. Do not refactor unrelated architecture during migration.
 - Course references are for deeper learning only. Use them sparingly and only when they clearly help answer the developer's question.
+- Remember that executor != isolation. A `nonisolated(nonsending)` function runs on the caller's executor but is NOT isolated to the caller's actor. `Task {}` inside it inherits static isolation (nonisolated), not the runtime executor.
+- Never use `DispatchSemaphore`, `NSCondition`, or other blocking primitives inside async contexts -- they can deadlock the cooperative thread pool.
+- `@concurrent` parameters are implicitly `sending` (not `Sendable`). Non-Sendable types in a disconnected region can be passed to `@concurrent` functions.
 
 ## Quick Fix Mode
 

--- a/swift-concurrency/references/actors.md
+++ b/swift-concurrency/references/actors.md
@@ -677,7 +677,11 @@ Need thread-safe mutable state?
    └─ Fine-grained locking? → Mutex
 ```
 
-## Further Learning
+## Key Sources
 
-For migration strategies, advanced patterns, and real-world examples, see [Swift Concurrency Course](https://www.swiftconcurrencycourse.com).
+- [SE-0306: Actors](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0306-actors.md) -- isolation model, reentrancy
+- [SE-0316: Global Actors](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0316-global-actors.md) -- @MainActor, inference rules
+- [SE-0392: Custom Actor Executors](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0392-custom-actor-executors.md) -- SerialExecutor, assumeIsolated
+- [SE-0433: Mutex](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0433-mutex.md) -- synchronous alternative to actors
+- [SE-0420: Inheritance of Actor Isolation](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0420-inheritance-of-actor-isolation.md) -- #isolation, isolated parameters
 

--- a/swift-concurrency/references/actors.md
+++ b/swift-concurrency/references/actors.md
@@ -365,22 +365,45 @@ async let _ = account.deposit(50)
 // Balance: 150
 ```
 
-### Solution
-
-Complete actor work before suspending:
+### Solution 1: Complete work before suspending
 
 ```swift
 func deposit(amount: Double) async {
     balance += amount
     print("Balance: \(balance)") // Before suspension
-    
+
     await logActivity("Deposited \(amount)")
 }
 ```
 
 **Rule**: Don't assume state is unchanged after `await`.
 
-> **Course Deep Dive**: This topic is covered in detail in [Lesson 5.7: Understanding actor reentrancy](https://www.swiftconcurrencycourse.com?utm_source=github&utm_medium=agent-skill&utm_campaign=lesson-reference)
+### Solution 2: Store Task for deduplication
+
+When multiple callers request the same work (e.g., fetching an image by URL), store the Task itself to avoid duplicate work:
+
+```swift
+actor ImageCache {
+    var inFlight: [URL: Task<UIImage, Error>] = [:]
+
+    func image(for url: URL) async throws -> UIImage {
+        if let existing = inFlight[url] {
+            return try await existing.value  // Wait for in-progress work
+        }
+
+        let task = Task {
+            let (data, _) = try await URLSession.shared.data(from: url)
+            return UIImage(data: data)!
+        }
+
+        inFlight[url] = task  // Store BEFORE await
+        defer { inFlight[url] = nil }
+        return try await task.value
+    }
+}
+```
+
+This pattern ensures only one network request per URL regardless of how many concurrent callers.
 
 ## #isolation Macro
 

--- a/swift-concurrency/references/async-await-basics.md
+++ b/swift-concurrency/references/async-await-basics.md
@@ -260,7 +260,9 @@ let profile = Profile(
 )
 ```
 
-## Further Learning
+## Key Sources
 
-For in-depth coverage of async/await patterns, error handling strategies, and real-world migration scenarios, see [Swift Concurrency Course](https://www.swiftconcurrencycourse.com).
+- [SE-0296: Async/Await](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0296-async-await.md) -- suspension semantics, execution model
+- [SE-0300: Continuations](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0300-continuation.md) -- bridging callback APIs
+- [SE-0298: AsyncSequence](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0298-asyncsequence.md) -- for-await iteration
 

--- a/swift-concurrency/references/glossary.md
+++ b/swift-concurrency/references/glossary.md
@@ -135,3 +135,12 @@ Like AsyncChannel but can emit errors through the stream. Stable operator.
 
 An AsyncSequence that emits a value at regular intervals. Replaces timer-based publishers and manual sleep loops. Stable operator.
 
+## Key Sources
+
+- [SE-0296: Async/Await](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0296-async-await.md)
+- [SE-0304: Structured Concurrency](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0304-structured-concurrency.md)
+- [SE-0306: Actors](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0306-actors.md)
+- [SE-0414: Region-Based Isolation](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0414-region-based-isolation.md)
+- [SE-0461: Async Function Isolation](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0461-async-function-isolation.md)
+- [SE-0466: Control Default Actor Isolation](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0466-control-default-actor-isolation.md)
+

--- a/swift-concurrency/references/glossary.md
+++ b/swift-concurrency/references/glossary.md
@@ -43,11 +43,11 @@ While an actor is suspended at an `await`, other tasks can enter the actor and m
 
 ## nonisolated
 
-Marks a declaration as not isolated to the surrounding actor/global actor. Use only when it truly does not touch isolated mutable state (typically immutable Sendable data).
+Marks a declaration as not isolated to the surrounding actor/global actor. Use only when it truly does not touch isolated mutable state (typically immutable Sendable data). Before Swift 6.2, `nonisolated async` functions always ran on the global executor (background). With `NonisolatedNonsendingByDefault`, they run on the caller’s executor instead.
 
 ## nonisolated(nonsending) (Swift 6.2+ behavior)
 
-An opt-out to prevent “sending” non-Sendable values across isolation while still allowing an async function to run in the caller’s isolation. Used to reduce Sendable friction when you do not need to hop executors.
+Causes an async function to run on the caller’s **executor** without crossing an isolation boundary, so no Sendable/sending checks apply. The function remains nonisolated -- it does not inherit the caller’s **isolation**. This means `Task {}` created inside it will be nonisolated, not isolated to the caller’s actor. See `threading.md` for the executor != isolation gotcha.
 
 ## @concurrent (Swift 6.2+ behavior)
 
@@ -72,6 +72,8 @@ A concrete implementation of `AsyncSequence` that bridges callback-based or dele
 ## Continuation
 
 A mechanism to bridge callback-based APIs to async/await. `withCheckedContinuation` and `withCheckedThrowingContinuation` provide safe bridging with runtime checks. `withUnsafeContinuation` variants skip checks for performance-critical code.
+
+**Critical rule: exactly once.** Each continuation must be resumed exactly once on every code path ([SE-0300](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0300-continuation.md)). Zero resumes = the Task hangs forever (memory leak). Two resumes = crash (checked) or undefined behavior (unsafe).
 
 ## Task Local
 

--- a/swift-concurrency/references/sendable.md
+++ b/swift-concurrency/references/sendable.md
@@ -427,7 +427,29 @@ func createArticle(title: String) -> sending Article {
 
 Transfers ownership to caller's region.
 
-> **Course Deep Dive**: This topic is covered in detail in [Lesson 4.8: Understanding region-based isolation and the sending keyword](https://www.swiftconcurrencycourse.com?utm_source=github&utm_medium=agent-skill&utm_campaign=lesson-reference)
+### @concurrent parameters are implicitly sending
+
+`@concurrent` functions (Swift 6.2) make their parameters implicitly `sending`. This means non-Sendable types CAN be passed if they are in a disconnected region:
+
+```swift
+class Parser {  // non-Sendable
+    func parse() -> Result { /* ... */ }
+}
+
+@concurrent
+func process(_ parser: Parser) async -> Result {
+    parser.parse()
+}
+
+@MainActor
+func example() async {
+    let parser = Parser()              // disconnected region
+    let result = await process(parser) // OK: parser transferred
+    // parser can no longer be used here
+}
+```
+
+This is NOT the same as requiring Sendable. The compiler uses region-based analysis per [SE-0414](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0414-region-based-isolation.md) to prove the transfer is safe.
 
 ## Global Variables
 

--- a/swift-concurrency/references/tasks.md
+++ b/swift-concurrency/references/tasks.md
@@ -671,7 +671,9 @@ The compiler does NOT catch logical races -- only data races. The synchronous ch
 6. **Set priority only when needed** (inherit by default)
 7. **Don't mutate task groups** from outside their creation context
 
-## Further Learning
+## Key Sources
 
-For hands-on examples, advanced patterns, and migration strategies, see [Swift Concurrency Course](https://www.swiftconcurrencycourse.com).
+- [SE-0304: Structured Concurrency](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0304-structured-concurrency.md) -- Task, TaskGroup, cancellation, priorities
+- [SE-0317: async let](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0317-async-let.md) -- parallel bindings
+- [SE-0311: Task Local Values](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0311-task-locals.md)
 

--- a/swift-concurrency/references/tasks.md
+++ b/swift-concurrency/references/tasks.md
@@ -612,6 +612,47 @@ let profile = Profile(
 )
 ```
 
+## Logical Races (not data races)
+
+Multiple Tasks created from the same context do NOT guarantee execution order. This is different from `DispatchQueue.async` which preserves FIFO order:
+
+```swift
+// These may complete in ANY order:
+Task { await step1() }
+Task { await step2() }
+```
+
+A common bug: double-tap creates two Tasks that interleave:
+
+```swift
+@MainActor
+class ViewModel {
+    var inProgress = false
+
+    func toggle() {
+        // WRONG: no guard -- two Tasks can interleave
+        Task {
+            await system.toggleState()
+            state = await system.state
+        }
+    }
+
+    // CORRECT: synchronous check BEFORE await
+    func toggleSafe() {
+        if inProgress { return }
+        inProgress = true
+
+        Task {
+            await system.toggleState()
+            state = await system.state
+            inProgress = false
+        }
+    }
+}
+```
+
+The compiler does NOT catch logical races -- only data races. The synchronous check must happen before any `await`.
+
 ## Common Mistakes Agents Make
 
 - Replacing structured child work with many unrelated top-level tasks.

--- a/swift-concurrency/references/threading.md
+++ b/swift-concurrency/references/threading.md
@@ -59,6 +59,34 @@ func example() async {
 }
 ```
 
+### Forward progress guarantee
+
+Every task on the cooperative pool must make forward progress. Blocking a thread without releasing it starves the pool.
+
+**Never do this in async contexts:**
+```swift
+// DEADLOCK RISK: semaphore blocks the thread, Task may never get a thread to signal
+func syncWrapper() -> Data {
+    let sem = DispatchSemaphore(value: 0)
+    var result: Data!
+    Task {
+        result = try? await fetchData()
+        sem.signal()  // May never execute if pool is exhausted
+    }
+    sem.wait()  // Blocks the thread
+    return result
+}
+```
+
+The pool can have as few as 1 thread (iOS Simulator). Use `DISPATCH_COOPERATIVE_POOL_STRICT=1` environment variable to test with a single-threaded pool.
+
+**Safe alternatives to blocking primitives:**
+- `Mutex.withLock {}` -- brief synchronous lock, does not depend on other tasks
+- `withCheckedContinuation` -- bridges callback APIs to async/await
+- `AsyncStream` -- bridges streaming data to async iteration
+
+Some code cannot be bridged to Swift Concurrency. If a synchronous delegate protocol requires an async result, the only safe options are: redesign the protocol to be async, or do not use Swift Concurrency for that code path.
+
 ### Benefits over GCD
 
 **Prevents thread explosion**:

--- a/swift-concurrency/references/threading.md
+++ b/swift-concurrency/references/threading.md
@@ -553,7 +553,9 @@ Instead of asking "what thread should this run on?" ask "what isolation domain s
 - Efficient task scheduling
 - Automatic load balancing
 
-## Further Learning
+## Key Sources
 
-For migration strategies, real-world examples, and advanced threading patterns, see [Swift Concurrency Course](https://www.swiftconcurrencycourse.com).
+- [SE-0461: Async Function Isolation](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0461-async-function-isolation.md) -- nonisolated(nonsending), @concurrent, executor != isolation
+- [SE-0466: Control Default Actor Isolation](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0466-control-default-actor-isolation.md) -- defaultIsolation
+- [Saagar Jha: Swift Concurrency Waits for No One](https://saagarjha.com/blog/2023/12/22/swift-concurrency-waits-for-no-one/) -- forward progress, cooperative pool
 

--- a/swift-concurrency/references/threading.md
+++ b/swift-concurrency/references/threading.md
@@ -236,14 +236,17 @@ func backgroundTask() async {
 
 ### Nonisolated async functions (SE-461)
 
-**Old behavior**: Nonisolated async functions always switch to background.
+**Old behavior**: Nonisolated async functions always switch to the global executor (background).
 
-**New behavior**: Inherit caller's isolation by default.
+**New behavior**: Run on the caller's **executor** by default.
+
+**Critical distinction**: The function inherits the caller's **executor** (where it runs), NOT the caller's **isolation** (what it can access). The function remains `nonisolated` -- it cannot access actor-isolated state.
 
 ```swift
 class NotSendable {
     func performAsync() async {
-        print(Thread.current)
+        // Runs on caller's executor (e.g. main thread if called from @MainActor)
+        // But is still nonisolated -- cannot access @MainActor state
     }
 }
 
@@ -252,9 +255,43 @@ func caller() async {
     let obj = NotSendable()
     await obj.performAsync()
     // Old: Background thread
-    // New: Main thread (inherits @MainActor)
+    // New: Main thread (runs on caller's executor)
 }
 ```
+
+### executor != isolation (critical gotcha)
+
+`nonisolated(nonsending)` changes WHERE code runs, but NOT what it can access:
+
+```swift
+@MainActor
+class ViewModel {
+    var count = 0
+
+    func doWork() async {
+        await helper()
+    }
+}
+
+nonisolated(nonsending) func helper() async {
+    // Runtime: runs on main thread (caller's executor)
+    // Compile-time: nonisolated (no access to @MainActor state)
+
+    Task {
+        // This Task inherits STATIC isolation of helper() -- nonisolated
+        // It does NOT inherit @MainActor, despite running on main thread
+        // viewModel.count += 1  // ERROR: main actor-isolated property
+    }
+}
+```
+
+**Why**: `Task {}` inherits static (compile-time) isolation, not the runtime executor.
+Per [SE-0461](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0461-async-function-isolation.md): "Unstructured tasks created within nonisolated functions do NOT inherit the caller's isolation automatically."
+
+**Correct patterns**:
+- Return data to the caller instead of creating Task inside nonisolated functions
+- Use `Task { @MainActor in }` for explicit isolation
+- Use `isolated (any Actor)? = #isolation` parameter for dynamic isolation
 
 ### Enabling new behavior
 
@@ -278,17 +315,16 @@ func performAsync() async {
 
 ### nonisolated(nonsending)
 
-Prevent sending non-Sendable values across isolation:
+Runs on the caller's **executor** without crossing an isolation boundary, so no Sendable/sending checks:
 
 ```swift
 nonisolated(nonsending) func storeTouch(...) async {
-    // Runs on caller's isolation, no value sending
+    // Runs on caller's executor, no isolation boundary crossed
 }
 ```
 
-> **Course Deep Dive**: This topic is covered in detail in [Lesson 7.4: Dispatching to different threads using nonisolated(nonsending) and @concurrent (Updated for Swift 6.2)](https://www.swiftconcurrencycourse.com?utm_source=github&utm_medium=agent-skill&utm_campaign=lesson-reference)
-
-**Use when**: Method doesn't need to switch isolation, avoiding Sendable requirements.
+**Use when**: Method doesn't need to switch executor, avoiding Sendable requirements.
+**Remember**: The function is still nonisolated -- it cannot access actor-isolated state, and `Task {}` inside it will be nonisolated.
 
 ## Default Isolation Domain (SE-466)
 


### PR DESCRIPTION
## Summary

Adds missing technical content and fixes inaccuracies found during cross-referencing skill content with Swift Evolution proposals (SE-0461, SE-0466, SE-0414, SE-0300, SE-0304, SE-0306).

### Changes by commit:

1. **executor != isolation distinction** (SKILL.md, threading.md) -- Documents that `nonisolated(nonsending)` inherits the caller's *executor* but NOT the caller's *isolation*. `Task {}` inside such a function is nonisolated. This is the most common Swift 6.2 gotcha and was not documented. Source: [SE-0461](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0461-async-function-isolation.md).

2. **Forward progress guarantee** (threading.md) -- Documents why `DispatchSemaphore.wait()` in async contexts causes deadlocks, `DISPATCH_COOPERATIVE_POOL_STRICT=1` for debugging, and that some code cannot be bridged to Swift Concurrency. Source: [Saagar Jha](https://saagarjha.com/blog/2023/12/22/swift-concurrency-waits-for-no-one/).

3. **Reentrancy deduplication pattern** (actors.md) -- Adds "store Task for deduplication" pattern (prevents duplicate network requests from actor reentrancy). **Logical races** (tasks.md) -- Documents that Task execution order is not FIFO (unlike DispatchQueue.async) and the synchronous guard pattern. Source: [Matt Massicotte](https://www.massicotte.org/step-by-step-stateful-systems/).

4. **@concurrent sending semantics** (sendable.md) -- Documents that `@concurrent` parameters are implicitly `sending`, not `Sendable`. Non-Sendable types in disconnected regions are allowed per [SE-0414](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0414-region-based-isolation.md). **Continuation exactly-once rule** (glossary.md) -- Adds the critical safety rule from [SE-0300](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0300-continuation.md). **Glossary fixes** -- Clarifies nonisolated behavior change with NonisolatedNonsendingByDefault; fixes nonisolated(nonsending) definition.

5. **SE proposal references** (6 files) -- Adds Key Sources sections with links to authoritative Swift Evolution proposals.

### Guardrails added to SKILL.md:

- executor != isolation warning for `nonisolated(nonsending)` + `Task {}`
- Never use `DispatchSemaphore`/`NSCondition` in async contexts
- `@concurrent` parameters are `sending`, not `Sendable`

## Test plan

- [ ] Verify all added code examples compile with Swift 6.2
- [ ] Review SE proposal links are valid and point to correct proposals
- [ ] Confirm no existing behavior or guidance was removed