### PR TITLE
docs: clarify delayed retry actor isolation

### DIFF
--- a/swift-concurrency/SKILL.md
+++ b/swift-concurrency/SKILL.md
@@ -11,7 +11,7 @@ Before proposing a fix:
 1. Analyze `Package.swift` or `.pbxproj` to determine Swift language mode, strict concurrency level, default isolation, and upcoming features. Do this always, not only for migration work.
 2. Capture the exact diagnostic and offending symbol.
 3. Determine the isolation boundary: `@MainActor`, custom actor, actor instance isolation, or `nonisolated`.
-4. Confirm whether the code is UI-bound or intended to run off the main actor.
+4. Confirm whether the code is UI-bound or intended to run off the main actor. For delayed retries, timers, and backoff tasks, separate the waiting from the UI mutation. The sleep often belongs off the main actor even when the final state update belongs on it.
 
 Project settings that change concurrency behavior:
 
@@ -72,7 +72,7 @@ Prefer changes that preserve behavior while satisfying data-race safety:
 
 - **UI-bound state**: isolate the type or member to `@MainActor`.
 - **Shared mutable state**: move it behind an `actor`, or use `@MainActor` only if the state is UI-owned.
-- **Background work**: when work must hop off caller isolation, use an `async` API marked `@concurrent`; when work can safely inherit caller isolation, use `nonisolated` without `@concurrent`.
+- **Background work**: when work must hop off caller isolation, use an `async` API marked `@concurrent`; when work can safely inherit caller isolation, use `nonisolated` without `@concurrent`. If a task mostly waits or retries before one UI-bound mutation, keep the delay off `@MainActor` and hop back only for the final update.
 - **Sendability issues**: prefer immutable values and explicit boundaries over `@unchecked Sendable`.
 
 ## Concurrency Tool Selection

--- a/swift-concurrency/references/performance.md
+++ b/swift-concurrency/references/performance.md
@@ -271,7 +271,38 @@ if Task.isCancelled {
 }
 ```
 
-### 5. Embrace parallelism
+### 5. Keep delay work off the main actor
+
+If the task only needs the main actor for the final mutation, do not start the whole retry flow on `@MainActor`.
+
+```swift
+// ❌ Waits to enter MainActor, then suspends immediately
+registrationRetryTask = Task { @MainActor [weak self] in
+    try? await Task.sleep(for: .milliseconds(100))
+    guard let self else { return }
+    self.registrationRetryTask = nil
+    self.updateConnectedTargetWindow()
+}
+```
+
+The delay itself is not UI work. Starting on `@MainActor` adds an avoidable executor wait before the task even reaches `Task.sleep`.
+
+```swift
+// ✅ Sleep off-main, hop back only for the UI-owned work
+registrationRetryTask = Task { @concurrent [weak self] in
+    try? await Task.sleep(for: .milliseconds(100))
+    guard let self else { return }
+
+    await MainActor.run {
+        self.registrationRetryTask = nil
+        self.updateConnectedTargetWindow()
+    }
+}
+```
+
+Use this pattern for delayed retries, backoff, and timer-like work where only the final state change is UI-owned.
+
+### 6. Embrace parallelism
 
 ```swift
 // ❌ Sequential

--- a/swift-concurrency/references/performance.md
+++ b/swift-concurrency/references/performance.md
@@ -276,7 +276,7 @@ if Task.isCancelled {
 If the task only needs the main actor for the final mutation, do not start the whole retry flow on `@MainActor`.
 
 ```swift
-// ❌ Waits to enter MainActor, then suspends immediately
+// ❌ Can wait for MainActor, then suspend immediately
 registrationRetryTask = Task { @MainActor [weak self] in
     try? await Task.sleep(for: .milliseconds(100))
     guard let self else { return }
@@ -285,12 +285,16 @@ registrationRetryTask = Task { @MainActor [weak self] in
 }
 ```
 
-The delay itself is not UI work. Starting on `@MainActor` adds an avoidable executor wait before the task even reaches `Task.sleep`.
+The delay itself is not UI work. Starting on `@MainActor` can add an avoidable executor wait before the task reaches `Task.sleep`, especially when the task is scheduled from another executor or while the main actor is busy.
 
 ```swift
 // ✅ Sleep off-main, hop back only for the UI-owned work
 registrationRetryTask = Task { @concurrent [weak self] in
-    try? await Task.sleep(for: .milliseconds(100))
+    do {
+        try await Task.sleep(for: .milliseconds(100))
+    } catch is CancellationError {
+        return
+    }
     guard let self else { return }
 
     await MainActor.run {

--- a/swift-concurrency/references/threading.md
+++ b/swift-concurrency/references/threading.md
@@ -141,6 +141,8 @@ let data = await fetchData() // Potential suspension
 2. **State can change** - mutable state may be modified during suspension
 3. **Actor reentrancy** - other tasks can access actor during suspension
 
+`Task.sleep` follows the same rule: it suspends the task rather than blocking a thread. That still does not make actor choice irrelevant. If a delayed retry starts on `@MainActor`, the task may first wait for main-actor availability only to suspend immediately. Prefer `@concurrent` when the delay itself is not UI-owned, then hop back with `MainActor.run` for the final UI mutation.
+
 ### Actor reentrancy example
 
 ```swift

--- a/swift-concurrency/references/threading.md
+++ b/swift-concurrency/references/threading.md
@@ -141,7 +141,7 @@ let data = await fetchData() // Potential suspension
 2. **State can change** - mutable state may be modified during suspension
 3. **Actor reentrancy** - other tasks can access actor during suspension
 
-`Task.sleep` follows the same rule: it suspends the task rather than blocking a thread. That still does not make actor choice irrelevant. If a delayed retry starts on `@MainActor`, the task may first wait for main-actor availability only to suspend immediately. Prefer `@concurrent` when the delay itself is not UI-owned, then hop back with `MainActor.run` for the final UI mutation.
+`Task.sleep` follows the same rule: it suspends the task rather than blocking a thread. That still does not make actor choice irrelevant. If a delayed retry starts on `@MainActor`, it may wait for main-actor availability before reaching `Task.sleep` when scheduled from another executor or while the main actor is busy. Prefer `@concurrent` when the delay itself is not UI-owned, then hop back with `MainActor.run` for the final UI mutation.
 
 ### Actor reentrancy example
 


### PR DESCRIPTION
## Summary
- teach the skill to separate delayed retry/backoff waits from the final UI mutation when only the mutation is `@MainActor`-owned
- add a concrete `Task.sleep` retry example showing `@concurrent` work with a final `MainActor.run` hop
- clarify in threading guidance that `Task.sleep` suspends the task, but starting on `@MainActor` can still add an avoidable executor wait

## Test plan
- [x] Review the updated documentation sections in `swift-concurrency/SKILL.md`
- [x] Review the new delayed-retry example in `swift-concurrency/references/performance.md`
- [x] Review the executor-choice clarification in `swift-concurrency/references/threading.md`
- [ ] Automated tests not run (documentation-only change)