### PR TITLE
Add SWIFT_APPROACHABLE_CONCURRENCY setting, Xcode 26 defaults note, and SendableMetatype diagnostic

### DIFF
--- a/swift-concurrency/SKILL.md
+++ b/swift-concurrency/SKILL.md
@@ -21,8 +21,11 @@ Project settings that change concurrency behavior:
 | Strict concurrency | `.enableExperimentalFeature("StrictConcurrency=targeted")` | `SWIFT_STRICT_CONCURRENCY` |
 | Default isolation | `.defaultIsolation(MainActor.self)` | `SWIFT_DEFAULT_ACTOR_ISOLATION` |
 | Upcoming features | `.enableUpcomingFeature("NonisolatedNonsendingByDefault")` | `SWIFT_UPCOMING_FEATURE_*` |
+| Approachable Concurrency | N/A (use individual upcoming features) | `SWIFT_APPROACHABLE_CONCURRENCY` |
 
-If any of these are unknown, ask the developer to confirm them before giving migration-sensitive guidance. Do not guess.
+> **Xcode 26 note**: New projects created in Xcode 26 will often start with `SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor` and `SWIFT_APPROACHABLE_CONCURRENCY = YES` enabled by default. Treat these as likely defaults for newly created projects, not as confirmed settings.
+
+If any of these are unknown, ask the developer to confirm them before giving migration-sensitive guidance. Do not guess, even for new Xcode 26 projects.
 
 Guardrails:
 
@@ -58,6 +61,7 @@ Skip Quick Fix Mode when any of these are true:
 | Core Data concurrency warnings | Are `NSManagedObject` instances crossing contexts or actors? | Pass `NSManagedObjectID` or map to a Sendable value type. | `references/core-data.md` |
 | `Thread.current` unavailable from asynchronous contexts | Are you debugging by thread instead of isolation? | Reason in terms of isolation and use Instruments/debugger instead. | `references/threading.md` |
 | SwiftLint concurrency-related warnings | Which specific lint rule triggered? | Use `references/linting.md` for rule intent and preferred fixes; avoid dummy awaits. | `references/linting.md` |
+| `... cannot satisfy conformance requirement for a 'Sendable' type parameter` (`SendableMetatype`) | Does the conformance carry global-actor isolation? | Remove actor isolation from the conformance, or avoid passing the metatype across isolation boundaries. See `SendableMetatype` section in `references/actors.md`. | `references/actors.md` |
 
 ## When Quick Fixes Fail
 

--- a/swift-concurrency/references/actors.md
+++ b/swift-concurrency/references/actors.md
@@ -332,6 +332,47 @@ extension PersonViewModel: @MainActor Equatable {
 
 > **Course Deep Dive**: This topic is covered in detail in [Lesson 5.6: Adding isolated conformance to protocols](https://www.swiftconcurrencycourse.com?utm_source=github&utm_medium=agent-skill&utm_campaign=lesson-reference)
 
+### `SendableMetatype` Error with Isolated Conformances
+
+Isolated conformances **cannot** satisfy a `SendableMetatype` requirement. This surfaces when you pass `MyClass.self` to a generic function whose type parameter requires `Sendable`.
+
+```swift
+protocol P {
+    static func doSomething()
+}
+
+func doSomethingStatic<T: P & SendableMetatype>(_ type: T.Type) { }  // explicitly requires a Sendable type/metatype
+
+@MainActor
+class C { }
+
+extension C: @MainActor P {
+    static func doSomething() { }
+}
+
+@MainActor
+func test(c: C) {
+    doSomethingStatic(C.self)
+    // ❌ main actor-isolated conformance of 'C' to 'P' cannot satisfy
+    //    conformance requirement for a 'Sendable' type parameter
+}
+```
+
+**Fix options**:
+
+1. Remove actor isolation from the original conformance if the protocol requirements don't access actor state:
+
+```swift
+@MainActor
+class C: P {
+    nonisolated static func doSomething() { }  // ✅ Non-isolated requirement on a non-isolated conformance
+}
+```
+
+2. Avoid passing the metatype across isolation boundaries — call the static method directly rather than routing through the generic function.
+
+3. Make the generic function actor-aware so it accepts an isolated conformance (requires changing the callee's signature).
+
 ## Actor Reentrancy
 
 **Critical**: State can change between suspension points.


### PR DESCRIPTION
## Changes

This PR adds three missing items identified via analysis of Swift 6.2 / Xcode 26 documentation using Context7.

### 1. `SWIFT_APPROACHABLE_CONCURRENCY` in project settings table (`SKILL.md`)

Added an `Approachable Concurrency` row to the "Project settings that change concurrency behavior" table. This Xcode build setting enables a bundle of upcoming concurrency features and is distinct from setting them individually in `Package.swift`. Without this entry, agents may not prompt developers to check whether it's active.

### 2. Xcode 26 new project defaults note (`SKILL.md`)

Added a callout below the settings table noting that new projects created in **Xcode 26** have both `SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor` and `SWIFT_APPROACHABLE_CONCURRENCY = YES` enabled by default. Without this, agents may give incorrect migration guidance to developers who started a project in Xcode 26 and haven't explicitly set these values.

### 3. `SendableMetatype` diagnostic (`SKILL.md` + `references/actors.md`)

Added a row to the Common Diagnostics table for the error:

```
... cannot satisfy conformance requirement for a 'Sendable' type parameter
```

This `SendableMetatype` error appears when an actor-isolated conformance (e.g., `@MainActor`) is used where a `Sendable` metatype is required — for example, passing `MyClass.self` to a generic function. Also added a `SendableMetatype` subsection in `references/actors.md` under "Global Actor Isolated Conformance" with a minimal reproducer and three fix options.

## Rationale

Identified via review of the Swift 6.2 / Xcode 26 official documentation:

- [`nonisolated-nonsending-by-default.md`](https://github.com/swiftlang/swift/blob/main/userdocs/diagnostics/nonisolated-nonsending-by-default.md)
- [`isolated-conformances.md`](https://github.com/swiftlang/swift/blob/main/userdocs/diagnostics/isolated-conformances.md)
- [`sendable-metatypes.md`](https://github.com/swiftlang/swift/blob/main/userdocs/diagnostics/sendable-metatypes.md)
- [Approachable Concurrency guide](https://fuckingapproachableswiftconcurrency.com)

## AI Assistance

Changes generated with GitHub Copilot (Claude Sonnet 4.6) using Context7 for live Swift 6.2 documentation verification, per the recommendations in CONTRIBUTING.md.