### PR TITLE
Shorten skill description

### DIFF
--- a/swift-concurrency/SKILL.md
+++ b/swift-concurrency/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: swift-concurrency
-description: Use when working on Swift Concurrency, including async/await, tasks, actors, @MainActor, Sendable, Swift 6 migration, data races, thread safety, callback-to-async refactors, or concurrency-related compiler, SwiftLint, or linter warnings.
+description: Diagnose Swift Concurrency issues, refactor callback-based code to async/await, and guide Swift 6 migration when working with tasks, actors, @MainActor, Sendable, data races, thread safety, or concurrency-related compiler and linter warnings.
 ---
 # Swift Concurrency
 

--- a/swift-concurrency/SKILL.md
+++ b/swift-concurrency/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: swift-concurrency
-description: 'Diagnose data races, convert callback-based code to async/await, implement actor isolation patterns, resolve Sendable conformance issues, and guide Swift 6 migration. Use when developers mention: (1) Swift Concurrency, async/await, actors, or tasks, (2) "use Swift Concurrency" or "modern concurrency patterns", (3) migrating to Swift 6, (4) data races or thread safety issues, (5) refactoring closures to async/await, (6) @MainActor, Sendable, or actor isolation, (7) concurrent code architecture or performance optimization, (8) concurrency-related linter warnings (SwiftLint or similar; e.g. async_without_await, Sendable/actor isolation/MainActor lint).'
+description: Use when working on Swift Concurrency, including async/await, tasks, actors, @MainActor, Sendable, Swift 6 migration, data races, thread safety, callback-to-async refactors, or concurrency-related compiler, SwiftLint, or linter warnings.
 ---
 # Swift Concurrency
 


### PR DESCRIPTION
Since skill descriptions are a part of the context, codex CLI warns about  truncated skill descriptions.

```
⚠ Warning: Exceeded skills context budget of 2%. Loaded skill descriptions were truncated by an average of 219 characters per skill.
```

This PR shortens the skill description from 657 characters to 237 characters.