### PR TITLE
Generalize Task entry-isolation guidance using synchronous-prefix rule

### DIFF
--- a/swift-concurrency/SKILL.md
+++ b/swift-concurrency/SKILL.md
@@ -11,7 +11,7 @@ Before proposing a fix:
 1. Analyze `Package.swift` or `.pbxproj` to determine Swift language mode, strict concurrency level, default isolation, and upcoming features. Do this always, not only for migration work.
 2. Capture the exact diagnostic and offending symbol.
 3. Determine the isolation boundary: `@MainActor`, custom actor, actor instance isolation, or `nonisolated`.
-4. Confirm whether the code is UI-bound or intended to run off the main actor. For delayed retries, timers, and backoff tasks, separate the waiting from the UI mutation. The sleep often belongs off the main actor even when the final state update belongs on it.
+4. Confirm whether the code is UI-bound or intended to run off the main actor. When spawning unstructured tasks, inspect the synchronous prefix (everything before the first `await`): start on `@MainActor` only when that prefix truly needs main-actor access; otherwise use `Task { @concurrent in ... }` and hop back with `MainActor.run` only after the suspension. A trivial non-main line (for example, `print`) followed by main-actor work in the same prefix is not a reason to use `@concurrent`. For delayed retries, timers, and backoff tasks, separate the waiting from the UI mutation. The sleep often belongs off the main actor even when the final state update belongs on it.
 
 Project settings that change concurrency behavior:
 
@@ -72,7 +72,7 @@ Prefer changes that preserve behavior while satisfying data-race safety:
 
 - **UI-bound state**: isolate the type or member to `@MainActor`.
 - **Shared mutable state**: move it behind an `actor`, or use `@MainActor` only if the state is UI-owned.
-- **Background work**: when work must hop off caller isolation, use an `async` API marked `@concurrent`; when work can safely inherit caller isolation, use `nonisolated` without `@concurrent`. If a task mostly waits or retries before one UI-bound mutation, keep the delay off `@MainActor` and hop back only for the final update.
+- **Background work**: when work must hop off caller isolation, use an `async` API marked `@concurrent`; when work can safely inherit caller isolation, use `nonisolated` without `@concurrent`. When spawning a `Task`, match entry isolation to its synchronous prefix. If nothing before the first `await` needs the main actor, use `Task { @concurrent in ... }` and hop back via `await MainActor.run { ... }` for the UI update. If the prefix mixes a trivial non-main statement with main-actor work, keep the inherited `@MainActor` start—splitting the cheap line off-main is not worth an extra hop.
 - **Sendability issues**: prefer immutable values and explicit boundaries over `@unchecked Sendable`.
 
 ## Concurrency Tool Selection
@@ -105,6 +105,40 @@ await withTaskGroup(of: ProcessedItem.self) { group in
     for await result in group {
         results.append(result)
     }
+}
+```
+
+
+## Task entry isolation
+
+Match a `Task`'s entry isolation to its synchronous prefix (everything from `{` to the first `await`).
+
+- If anything in that prefix needs `@MainActor`, keep the inherited `@MainActor` start.
+- If nothing in that prefix needs `@MainActor`, prefer `Task { @concurrent in ... }` and hop back only for UI-owned mutation.
+
+```swift
+// ❌ Synchronous prefix is empty; first work hops away
+Task {
+    await hopToOtherIsolationDomain()
+}
+
+// ❌ Synchronous prefix is only `print` (trivial, non-main); first await hops away
+Task {
+    print("Also not main-thread-bound")
+    await hopToOtherIsolationDomain()
+}
+
+// ✅ Start off the main actor, hop back only for UI work
+Task { @concurrent in
+    await hopToOtherIsolationDomain()
+    await MainActor.run { updateUI() }
+}
+
+// ✅ Synchronous prefix DOES contain main-actor work — keep inheritance
+Task {
+    print("debug")              // trivial, non-main — rides along
+    self.isLoading = true       // needs @MainActor, before any await
+    await fetchData()
 }
 ```
 

--- a/swift-concurrency/references/glossary.md
+++ b/swift-concurrency/references/glossary.md
@@ -52,6 +52,7 @@ An opt-out to prevent “sending” non-Sendable values across isolation while s
 ## @concurrent (Swift 6.2+ behavior)
 
 An attribute used to explicitly opt a nonisolated async function into concurrent execution (i.e., not inheriting the caller’s actor). It is used during migration when enabling `NonisolatedNonsendingByDefault`.
+Also valid on `Task { @concurrent in ... }` to opt the task body out of the enclosing actor's isolation; pick this when the task's synchronous prefix (everything before the first `await`) does not need the main actor.
 
 ## @preconcurrency
 

--- a/swift-concurrency/references/performance.md
+++ b/swift-concurrency/references/performance.md
@@ -271,9 +271,37 @@ if Task.isCancelled {
 }
 ```
 
-### 5. Keep delay work off the main actor
+### 5. Match Task entry isolation to its synchronous prefix
 
-If the task only needs the main actor for the final mutation, do not start the whole retry flow on `@MainActor`.
+For unstructured `Task { ... }`, decide startup isolation from the synchronous prefix (everything before the first `await`). If that prefix needs main-actor access, keep inherited `@MainActor` entry. If the prefix does not need main actor, use `Task { @concurrent in ... }` and hop back with `MainActor.run` only when UI-owned mutation is required. A trivial non-main line (such as `print`) does **not** justify `@concurrent` when main-actor work already exists in the same prefix.
+
+```swift
+// ❌ Synchronous prefix is empty; first work hops away
+Task {
+    await hopToOtherIsolationDomain()
+}
+
+// ❌ Synchronous prefix is only `print` (trivial, non-main); first await hops away
+Task {
+    print("Also not main-thread-bound")
+    await hopToOtherIsolationDomain()
+}
+
+// ✅ Start off the main actor, hop back only for UI work
+Task { @concurrent in
+    await hopToOtherIsolationDomain()
+    await MainActor.run { updateUI() }
+}
+
+// ✅ Synchronous prefix DOES contain main-actor work — keep inheritance
+Task {
+    print("debug")              // trivial, non-main — rides along
+    self.isLoading = true       // needs @MainActor, before any await
+    await fetchData()
+}
+```
+
+Delayed retry is one specialization of this rule:
 
 ```swift
 // ❌ Can wait for MainActor, then suspend immediately
@@ -285,7 +313,7 @@ registrationRetryTask = Task { @MainActor [weak self] in
 }
 ```
 
-The delay itself is not UI work. Starting on `@MainActor` can add an avoidable executor wait before the task reaches `Task.sleep`, especially when the task is scheduled from another executor or while the main actor is busy.
+The delay itself is not UI work. Starting on `@MainActor` can add an avoidable executor wait before reaching `Task.sleep`, especially when scheduled from another executor or while the main actor is busy.
 
 ```swift
 // ✅ Sleep off-main, hop back only for the UI-owned work
@@ -304,7 +332,7 @@ registrationRetryTask = Task { @concurrent [weak self] in
 }
 ```
 
-Use this pattern for delayed retries, backoff, and timer-like work where only the final state change is UI-owned.
+Use this rule for any unstructured task: delayed retries, backoff, timer-like work, off-main computation, and actor hops. The key check is always “what runs before the first `await`?”, not “what does the task eventually do?”.
 
 ### 6. Embrace parallelism
 
@@ -514,6 +542,10 @@ Before optimizing, ask:
 - [ ] Are suspensions necessary?
 - [ ] Does UX require background work?
 - [ ] Will this scale with data?
+
+Anti-patterns to avoid with unstructured tasks:
+- Starting on inherited `@MainActor` when nothing in the synchronous prefix (before first `await`) needs main actor.
+- Moving trivial non-main lines off `@MainActor` when the same synchronous prefix already includes required main-actor mutation.
 
 ## Common Patterns
 

--- a/swift-concurrency/references/tasks.md
+++ b/swift-concurrency/references/tasks.md
@@ -34,6 +34,31 @@ func synchronousMethod() {
 }
 ```
 
+
+### Task entry isolation
+
+`Task { ... }` inherits the enclosing isolation domain. This is especially easy to miss in modules that use `defaultIsolation(MainActor.self)` because bare tasks then start on `@MainActor` by default.
+
+Choose task entry isolation using the synchronous prefix rule (everything before the first `await`):
+- If the prefix needs main-actor work, keep inherited `@MainActor` entry.
+- If the prefix does not need main actor, prefer `Task { @concurrent in ... }` and hop back only for UI mutation.
+
+```swift
+// ❌ Prefix has no main-actor work; first await hops away
+Task {
+    await someActor.refresh()
+}
+
+// ✅ Prefix needs @MainActor; keep inherited main start
+Task {
+    print("debug")        // trivial non-main line rides along
+    self.isLoading = true  // main-actor state before first await
+    await fetchData()
+}
+```
+
+For deeper guidance and expanded examples, see `references/threading.md#choosing-task-entry-isolation`.
+
 ## Task References
 
 Storing a reference is optional but enables cancellation and result waiting:
@@ -618,6 +643,7 @@ let profile = Profile(
 - Using `Task.detached` just to "make it background."
 - Ignoring cancellation in long-running operations.
 - Keeping a stored task forever without a clear owner or cleanup path.
+- Picking entry isolation from the enclosing context rather than the task's synchronous prefix — `Task { await someActor.x() }` from a `@MainActor` context should be `Task { @concurrent in ... }`; a `Task` whose prefix mutates `@MainActor` state should stay on inherited `@MainActor` even if it also has a `print`.
 - Priorities are hints, not guarantees. The system automatically elevates priority to prevent inversion (e.g., a high-priority task awaiting `.value` of a lower-priority task). Do not rely on priority for correctness.
 
 ## Best Practices

--- a/swift-concurrency/references/tasks.md
+++ b/swift-concurrency/references/tasks.md
@@ -57,7 +57,7 @@ Task {
 }
 ```
 
-For deeper guidance and expanded examples, see `references/threading.md#choosing-task-entry-isolation`.
+For deeper guidance and expanded examples, see `threading.md#choosing-task-entry-isolation`.
 
 ## Task References
 

--- a/swift-concurrency/references/threading.md
+++ b/swift-concurrency/references/threading.md
@@ -141,7 +141,7 @@ let data = await fetchData() // Potential suspension
 2. **State can change** - mutable state may be modified during suspension
 3. **Actor reentrancy** - other tasks can access actor during suspension
 
-`Task.sleep` follows the same rule: it suspends the task rather than blocking a thread. That still does not make actor choice irrelevant. If a delayed retry starts on `@MainActor`, it may wait for main-actor availability before reaching `Task.sleep` when scheduled from another executor or while the main actor is busy. Prefer `@concurrent` when the delay itself is not UI-owned, then hop back with `MainActor.run` for the final UI mutation.
+The same entry-isolation rule applies to any unstructured task: choose startup isolation by what the synchronous prefix needs. If nothing before the first `await` needs the main actor—whether that first operation is `Task.sleep`, an actor hop, a `print`, or a Sendable computation—prefer `Task { @concurrent in ... }` and hop back with `MainActor.run` only for the UI mutation. If the synchronous prefix already needs main actor for one statement, keep nearby cheap lines on main with it instead of splitting them out.
 
 ### Actor reentrancy example
 
@@ -191,6 +191,47 @@ func deposit(amount: Int) async {
 **Rule**: Don't mutate actor state after suspension points.
 
 > **Course Deep Dive**: This topic is covered in detail in [Lesson 7.3: Understanding Task suspension points](https://www.swiftconcurrencycourse.com?utm_source=github&utm_medium=agent-skill&utm_campaign=lesson-reference)
+
+
+## Choosing Task entry isolation
+
+For unstructured `Task { ... }`, choose entry isolation based on the synchronous prefix (everything before the first `await`), not on where the task was created.
+
+Two common reasons a bare `Task { ... }` starts on `@MainActor`:
+- The task is spawned from a `@MainActor` context.
+- The module enables default main-actor isolation (for example, `defaultIsolation(MainActor.self)`).
+
+Rule:
+- If the synchronous prefix contains any main-actor work, keep inherited main-actor entry.
+- If the synchronous prefix contains no main-actor work, start with `Task { @concurrent in ... }` and hop back to `MainActor` only when needed.
+
+```swift
+// ❌ Synchronous prefix is empty; first work hops away
+Task {
+    await hopToOtherIsolationDomain()
+}
+
+// ❌ Synchronous prefix is only `print` (trivial, non-main); first await hops away
+Task {
+    print("Also not main-thread-bound")
+    await hopToOtherIsolationDomain()
+}
+
+// ✅ Start off the main actor, hop back only for UI work
+Task { @concurrent in
+    await hopToOtherIsolationDomain()
+    await MainActor.run { updateUI() }
+}
+
+// ✅ Synchronous prefix DOES contain main-actor work — keep inheritance
+Task {
+    print("debug")              // trivial, non-main — rides along
+    self.isLoading = true       // needs @MainActor, before any await
+    await fetchData()
+}
+```
+
+The delayed-retry `Task.sleep` case from PR #38 is a specialization of this same rule: the wait is usually not UI-owned, while the final mutation is.
 
 ## Thread Execution Patterns
 
@@ -474,6 +515,7 @@ Instead of asking "what thread should this run on?" ask "what isolation domain s
 - Debugging correctness by thread ID instead of by isolation and ordering.
 - Treating `await` as a blocking call — it suspends the task, freeing the thread.
 - Mapping each `Task` to a conceptual thread.
+- Picking task entry isolation by the enclosing context instead of by the task's synchronous prefix. A `Task { ... }` from `@MainActor` whose first `await` immediately hops away (with no main-actor work before it) should usually be `Task { @concurrent in ... }`.
 
 ## Performance Insights
 

--- a/swift-concurrency/references/threading.md
+++ b/swift-concurrency/references/threading.md
@@ -231,7 +231,9 @@ Task {
 }
 ```
 
-The delayed-retry `Task.sleep` case from PR #38 is a specialization of this same rule: the wait is usually not UI-owned, while the final mutation is.
+The delayed-retry `Task.sleep` pattern (see `performance.md` "Match Task entry isolation to its synchronous prefix") is a specialization of this same rule: the wait is usually not UI-owned, while the final mutation is.
+
+Note that `Task { @concurrent in ... }` changes the closure's isolation, so any capture of non-Sendable state from the enclosing actor must move inside the `MainActor.run { ... }` hop, or be captured weakly (e.g., `[weak self]` plus a `guard let self`) before being used there. The examples above stay safe by keeping `self` use inside `MainActor.run`. If the body needs to touch non-Sendable state directly, see `sendable.md` before reaching for `@concurrent`.
 
 ## Thread Execution Patterns
 


### PR DESCRIPTION
### Motivation

- Make the guidance introduced in a narrow delayed-retry example into a general, easy-to-follow decision rule: pick a `Task`'s entry isolation by what its synchronous prefix (everything before the first `await`) actually needs.
- Prevent accidental main-actor scheduling caused by `defaultIsolation(MainActor.self)` or spawning `Task { ... }` from `@MainActor` contexts when the prefix contains no main-actor work.
- Clarify the trivial-non-main exception (e.g., a `print` that should "ride along") so authors do not split cheap lines off `@MainActor` unnecessarily.

### Description

- Strengthened Fast Path and Smallest Safe Fixes in `swift-concurrency/SKILL.md`, and added a new "Task entry isolation" subsection with the four canonical ❌/✅ examples that show the synchronous-prefix rule and the trivial-non-main exception.
- Added `Choosing Task entry isolation` to `swift-concurrency/references/threading.md`, generalized the `Task.sleep` guidance into the broader synchronous-prefix rule, and added a common-mistake bullet about choosing entry isolation from enclosing context instead of the synchronous prefix.
- Reworked Section 5 in `swift-concurrency/references/performance.md` into "Match Task entry isolation to its synchronous prefix", led with the general rule, kept the delayed-retry example as a specialization, and added anti-pattern notes for both over-/under-use of `@concurrent`.
- Added a short "Task entry isolation" subsection and a common-mistakes bullet to `swift-concurrency/references/tasks.md`, and extended `swift-concurrency/references/glossary.md` `@concurrent` entry to mention `Task { @concurrent in ... }` usage tied to the synchronous-prefix decision rule.

### Testing

- Ran a targeted grep to confirm the synchronous-prefix guidance appears in each target file with `rg -n "synchronous prefix|before the first \`await\`" swift-concurrency/SKILL.md swift-concurrency/references/threading.md swift-concurrency/references/performance.md swift-concurrency/references/tasks.md`, and all expected matches were present.
- Verified presence of the canonical examples using `rg -n "hopToOtherIsolationDomain|print(\"debug\")|trivial, non-main" swift-concurrency/*.md swift-concurrency/references/*.md`, and found the ❌/✅ snippets in the updated docs.
- Ran the same text-checks after edits to ensure consistency across the updated files, and all checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f842e601e4832784aa77595ef1bb46)