### PR TITLE
Focus README on primary install paths; move the rest to INSTALLATION.md

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -1,0 +1,79 @@
+# All Installation Options
+
+The [README](README.md) covers the recommended installation paths: [skills.sh](README.md#option-a-using-skillssh-recommended), the OpenAI Plugins Directory (ChatGPT & Codex), Claude Code, and Cursor. This file lists every other supported client.
+
+## pi package manager
+
+Install via [pi](https://github.com/mariozechner/pi-mono):
+```bash
+pi install https://github.com/AvdLee/Swift-Concurrency-Agent-Skill
+```
+
+The skill will be available automatically in pi sessions.
+
+## Gemini CLI
+
+Install globally (user-level skill available in all Gemini CLI sessions):
+```bash
+gemini skills install https://github.com/AvdLee/Swift-Concurrency-Agent-Skill
+```
+
+Or install at workspace level so the skill is shared with your team via version control:
+```bash
+gemini skills install https://github.com/AvdLee/Swift-Concurrency-Agent-Skill --scope workspace
+```
+
+You can verify the installation with:
+```bash
+gemini skills list
+```
+
+For more information, see the [Gemini CLI Agent Skills documentation](https://geminicli.com/docs/cli/skills/).
+
+*Instructions contributed by [@clanzhang](https://github.com/clanzhang).*
+
+## Autohand Code
+
+Install the skill globally:
+```bash
+git clone https://github.com/AvdLee/Swift-Concurrency-Agent-Skill.git
+mkdir -p ~/.autohand/skills
+cp -R Swift-Concurrency-Agent-Skill/skills/swift-concurrency ~/.autohand/skills/
+```
+
+Or install it only for the current project:
+```bash
+git clone https://github.com/AvdLee/Swift-Concurrency-Agent-Skill.git
+mkdir -p .autohand/skills
+cp -R Swift-Concurrency-Agent-Skill/skills/swift-concurrency .autohand/skills/
+```
+
+Autohand Code discovers skills from `~/.autohand/skills/` and `.autohand/skills/`.
+
+*Instructions contributed by [@igorcosta](https://github.com/igorcosta).*
+
+## Manual install
+
+1) **Clone** this repository.
+2) **Install or symlink** the `skills/swift-concurrency/` folder following your tool's official skills installation docs (see links below).
+3) **Use your AI tool** as usual and ask it to use the "swift-concurrency" skill for Swift Concurrency tasks.
+
+> Note: the skill folder moved from the repository root to `skills/swift-concurrency/` when adopting the Agent Plugins format. A symlink at the old `swift-concurrency/` path keeps existing local clones and scripts working; it will be removed in the next major version.
+
+### Where to Save Skills
+
+Follow your tool's official documentation, here are a few popular ones:
+- **Codex:** [Where to save skills](https://developers.openai.com/codex/skills/#where-to-save-skills)
+- **Claude:** [Using Skills](https://docs.claude.com/en/docs/agents-and-tools/agent-skills/overview)
+- **Cursor:** [Enabling Skills](https://cursor.com/docs/context/skills#enabling-skills)
+- **Gemini CLI:** [Agent Skills](https://geminicli.com/docs/cli/skills/)
+- **Autohand Code:** `~/.autohand/skills/` or `.autohand/skills/`
+
+**How to verify:**
+
+Your agent should reference the triage/playbook in `skills/swift-concurrency/SKILL.md` and jump into the relevant reference file for your error or task.
+
+## Trigger the skill
+
+After installing through any of these options, use the skill in your AI agent, for example:
+> Use the swift concurrency skill and analyze the current project for Swift Concurrency improvements

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Expert guidance for any AI coding tool that supports the [Agent Skills open form
 
 Based on the comprehensive [Swift Concurrency Course](https://www.swiftconcurrencycourse.com?utm_source=github&utm_medium=agent-skill&utm_campaign=swift-concurrency-skill), distilled into actionable, concise references for agents.
 
-This repository is packaged as a portable [Agent Plugin](https://agent-plugins.org) (spec 1.0.0): compatible clients discover the skill automatically from the root `plugin.json` manifest and the `skills/` directory. Client-specific manifests for Claude Code, Cursor, Codex, and pi are included as well.
+This repository is packaged as a portable [Agent Plugin](https://agent-plugins.org) (spec 1.0.0): compatible clients discover the skill automatically from the root `plugin.json` manifest and the `skills/` directory. Client-specific manifests for Claude Code, Cursor, Codex, and pi are included as well, and the plugin is published in the OpenAI Plugins Directory for ChatGPT and Codex.
 
 ## Who this is for
 - Teams migrating to Swift 6 / strict concurrency who need safe defaults and quick triage.
@@ -35,7 +35,15 @@ For more information, visit the [skills.sh platform page](https://skills.sh/avdl
 Then use the skill in your AI agent, for example:  
 > Use the swift concurrency skill and analyze the current project for Swift Concurrency improvements
 
-### Option B: Claude Code Plugin
+### Option B: ChatGPT & Codex (OpenAI Plugins Directory)
+
+This plugin is published in the universal OpenAI Plugins Directory shared by ChatGPT and Codex:
+
+1. In the ChatGPT desktop app, select **Codex** (or ChatGPT with **Work** enabled), or use the plugin browser in Codex CLI.
+2. Open **Plugins** and search for "Swift Concurrency".
+3. Install the plugin. The skill becomes available in new chats and sessions.
+
+### Option C: Claude Code Plugin
 
 #### Personal Usage
 
@@ -73,32 +81,13 @@ To automatically provide this Skill to everyone working in a repository, configu
 
 When team members open the project, Claude Code will prompt them to install the Skill.
 
-### Option C: Using pi package manager
-
-Install via [pi](https://github.com/mariozechner/pi-mono):
-```bash
-pi install https://github.com/AvdLee/Swift-Concurrency-Agent-Skill
-```
-
-The skill will be available automatically in pi sessions.
-
 ### Option D: Cursor Plugin
 
 Load the plugin from a local clone by placing it in `~/.cursor/plugins/local`, or install it from the Cursor Marketplace once listed. Cursor supports both the portable Agent Plugins manifest (`plugin.json`) and the Cursor Plugin manifest (`.cursor-plugin/plugin.json`) included in this repository.
 
-### Option E: Manual install
-1) **Clone** this repository.  
-2) **Install or symlink** the `skills/swift-concurrency/` folder following your tool’s official skills installation docs (see links below).  
-3) **Use your AI tool** as usual and ask it to use the “swift-concurrency” skill for Swift Concurrency tasks.
+### Using another tool?
 
-> Note: the skill folder moved from the repository root to `skills/swift-concurrency/` when adopting the Agent Plugins format. A symlink at the old `swift-concurrency/` path keeps existing local clones and scripts working; it will be removed in the next major version.
-
-#### Where to Save Skills
-
-Follow your tool’s official documentation, here are a few popular ones:
-- **Codex:** [Where to save skills](https://developers.openai.com/codex/skills/#where-to-save-skills)
-- **Claude:** [Using Skills](https://docs.claude.com/en/docs/agents-and-tools/agent-skills/overview)
-- **Cursor:** [Enabling Skills](https://cursor.com/docs/context/skills#enabling-skills)
+See [INSTALLATION.md](INSTALLATION.md) for all other installation options: pi, Gemini CLI, Autohand Code, and manual installation.
 
 **How to verify**: 
 
@@ -170,9 +159,9 @@ This skill gives your AI coding tool comprehensive Swift Concurrency guidance. I
 skills/swift-concurrency/
 ├── SKILL.md                # Main skill file with decision trees
 └── references/
-    ├── _index.md               # TODO: Add description
+    ├── _index.md               # Quick navigation index for all reference files
     ├── actors.md               # Actor isolation, global actors, reentrancy
-    ├── async-algorithms.md     # TODO: Add description
+    ├── async-algorithms.md     # AsyncAlgorithms operators: debounce, merge, zip, Combine migration
     ├── async-await-basics.md   # Fundamentals of async/await syntax
     ├── async-sequences.md      # AsyncSequence and AsyncStream patterns
     ├── core-data.md            # Core Data integration patterns


### PR DESCRIPTION
## Summary
- The README install section now focuses on the primary paths: skills.sh (recommended, works across all major clients), the OpenAI Plugins Directory (ChatGPT & Codex — newly published), Claude Code, and Cursor.
- All other install options move to a new `INSTALLATION.md`: pi, Gemini CLI, Autohand Code, and manual installation.
- Incorporates the Gemini CLI instructions from #45 (thanks @clanzhang) and the Autohand Code instructions from #46 (thanks @igorcosta), both updated for the `skills/swift-concurrency/` layout introduced with the Agent Plugins format.
- Fills in the two remaining `TODO: Add description` entries in the Skill Structure listing.

Closes #45
Closes #46

## Test plan
- [ ] Verify README renders with the four focused options and the INSTALLATION.md pointer
- [ ] Verify INSTALLATION.md links and paths (skills/swift-concurrency/) are correct